### PR TITLE
Revert "Add tests directory for tuple tests"

### DIFF
--- a/scripts/gen/main.go
+++ b/scripts/gen/main.go
@@ -75,7 +75,7 @@ func main() {
 				tpl:      codeTpl,
 			},
 			{
-				fullPath: path.Join(outputDir, "tests", fmt.Sprintf("tuple%d_test.go", tupleLength)),
+				fullPath: path.Join(outputDir, fmt.Sprintf("tuple%d_test.go", tupleLength)),
 				tpl:      testTpl,
 			},
 		}

--- a/scripts/gen/tuple_test.tpl
+++ b/scripts/gen/tuple_test.tpl
@@ -1,10 +1,9 @@
-package tuple_test
+package tuple
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/barweiss/go-tuple"
 )
 
 {{/* These variables can be used when the context of dot changes. */}}
@@ -12,8 +11,8 @@ import (
 {{$len := .Len}}
 
 func TestT{{.Len}}_New(t *testing.T) {
-	tup := tuple.New{{len .Indexes}}({{range .Indexes}}{{. | quote}},{{end}})
-	require.Equal(t, tuple.T{{.Len}}[{{range $i, $index := .Indexes}}{{if gt $i 0}}, {{end}}string{{end}}]{
+	tup := New{{len .Indexes}}({{range .Indexes}}{{. | quote}},{{end}})
+	require.Equal(t, T{{.Len}}[{{range $i, $index := .Indexes}}{{if gt $i 0}}, {{end}}string{{end}}]{
 		{{range .Indexes -}}
 		V{{.}}: {{. | quote}},
 		{{end}}
@@ -21,12 +20,12 @@ func TestT{{.Len}}_New(t *testing.T) {
 }
 
 func TestT{{.Len}}_Len(t *testing.T) {
-	tup := tuple.New{{len .Indexes}}({{range .Indexes}}{{. | quote}},{{end}})
+	tup := New{{len .Indexes}}({{range .Indexes}}{{. | quote}},{{end}})
 	require.Equal(t, {{.Len}}, tup.Len())
 }
 
 func TestT{{.Len}}_Values(t *testing.T) {
-	tup := tuple.New{{len .Indexes}}({{range .Indexes}}{{. | quote}},{{end}})
+	tup := New{{len .Indexes}}({{range .Indexes}}{{. | quote}},{{end}})
 	{{range $i, $index := .Indexes}}{{if gt $i 0}}, {{end}}v{{$index}}{{end}} := tup.Values()
 	{{range .Indexes -}}
 	require.Equal(t, {{. | quote}}, v{{.}})
@@ -34,12 +33,12 @@ func TestT{{.Len}}_Values(t *testing.T) {
 }
 
 func TestT{{.Len}}_String(t *testing.T) {
-	tup := tuple.New{{len .Indexes}}({{range .Indexes}}{{. | quote}},{{end}})
+	tup := New{{len .Indexes}}({{range .Indexes}}{{. | quote}},{{end}})
 	require.Equal(t, `[{{range $i, $index := .Indexes}}{{if gt $i 0}} {{end}}{{. | quote}}{{end}}]`, tup.String())
 }
 
 func TestT{{.Len}}_GoString(t *testing.T) {
-	tup := tuple.New{{len .Indexes}}({{range .Indexes}}{{. | quote}},{{end}})
+	tup := New{{len .Indexes}}({{range .Indexes}}{{. | quote}},{{end}})
 	require.Equal(t, `tuple.T{{.Len}}[{{range $i, $index := .Indexes}}{{if gt $i 0}}, {{end}}string{{end}}]{
 		{{- range $i, $index := .Indexes -}}
 		{{- if gt $i 0}}, {{end -}}
@@ -49,14 +48,14 @@ func TestT{{.Len}}_GoString(t *testing.T) {
 }
 
 func TestT{{.Len}}_ToArray(t *testing.T) {
-	tup := tuple.New{{len .Indexes}}({{range .Indexes}}{{. | quote}},{{end}})
+	tup := New{{len .Indexes}}({{range .Indexes}}{{. | quote}},{{end}})
 	require.Equal(t, [{{.Len}}]any{
 		{{range .Indexes -}}{{. | quote}},{{end}}
 	}, tup.Array())
 }
 
 func TestT{{.Len}}_ToSlice(t *testing.T) {
-	tup := tuple.New{{len .Indexes}}({{range .Indexes}}{{. | quote}},{{end}})
+	tup := New{{len .Indexes}}({{range .Indexes}}{{. | quote}},{{end}})
 	require.Equal(t, []any{
 		{{range .Indexes -}}{{. | quote}},{{end}}
 	}, tup.Slice())
@@ -94,8 +93,8 @@ func TestT{{.Len}}_FromArrayX(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			do := func () tuple.T{{.Len}}[{{range $i, $index := .Indexes}}{{if gt $i 0}}, {{end}}string{{end}}] {
-				return tuple.FromArray{{.Len}}X[{{range $i, $index := .Indexes}}{{if gt $i 0}}, {{end}}string{{end}}](tt.array)
+			do := func () T{{.Len}}[{{range $i, $index := .Indexes}}{{if gt $i 0}}, {{end}}string{{end}}] {
+				return FromArray{{.Len}}X[{{range $i, $index := .Indexes}}{{if gt $i 0}}, {{end}}string{{end}}](tt.array)
 			}
 
 			if tt.wantPanic {
@@ -105,7 +104,7 @@ func TestT{{.Len}}_FromArrayX(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, tuple.New{{len .Indexes}}({{range .Indexes}}{{. | quote}},{{end}}), do())
+			require.Equal(t, New{{len .Indexes}}({{range .Indexes}}{{. | quote}},{{end}}), do())
 		})
 	}
 }
@@ -142,14 +141,14 @@ func TestT{{.Len}}_FromArray(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tup, err := tuple.FromArray{{.Len}}[{{range $i, $index := .Indexes}}{{if gt $i 0}}, {{end}}string{{end}}](tt.array)
+			tup, err := FromArray{{.Len}}[{{range $i, $index := .Indexes}}{{if gt $i 0}}, {{end}}string{{end}}](tt.array)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tuple.New{{len .Indexes}}({{range .Indexes}}{{. | quote}},{{end}}), tup)
+			require.Equal(t, New{{len .Indexes}}({{range .Indexes}}{{. | quote}},{{end}}), tup)
 		})
 	}
 }
@@ -206,8 +205,8 @@ func TestT{{.Len}}_FromSliceX(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			do := func () tuple.T{{.Len}}[{{range $i, $index := .Indexes}}{{if gt $i 0}}, {{end}}string{{end}}] {
-				return tuple.FromSlice{{.Len}}X[{{range $i, $index := .Indexes}}{{if gt $i 0}}, {{end}}string{{end}}](tt.slice)
+			do := func () T{{.Len}}[{{range $i, $index := .Indexes}}{{if gt $i 0}}, {{end}}string{{end}}] {
+				return FromSlice{{.Len}}X[{{range $i, $index := .Indexes}}{{if gt $i 0}}, {{end}}string{{end}}](tt.slice)
 			}
 
 			if tt.wantPanic {
@@ -217,7 +216,7 @@ func TestT{{.Len}}_FromSliceX(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, tuple.New{{len .Indexes}}({{range .Indexes}}{{. | quote}},{{end}}), do())
+			require.Equal(t, New{{len .Indexes}}({{range .Indexes}}{{. | quote}},{{end}}), do())
 		})
 	}
 }
@@ -274,14 +273,14 @@ func TestT{{.Len}}_FromSlice(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tup, err := tuple.FromSlice{{.Len}}[{{range $i, $index := .Indexes}}{{if gt $i 0}}, {{end}}string{{end}}](tt.slice)
+			tup, err := FromSlice{{.Len}}[{{range $i, $index := .Indexes}}{{if gt $i 0}}, {{end}}string{{end}}](tt.slice)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tuple.New{{len .Indexes}}({{range .Indexes}}{{. | quote}},{{end}}), tup)
+			require.Equal(t, New{{len .Indexes}}({{range .Indexes}}{{. | quote}},{{end}}), tup)
 		})
 	}
 }

--- a/tuple1_test.go
+++ b/tuple1_test.go
@@ -1,87 +1,78 @@
-package tuple_test
+package tuple
 
 import (
 	"testing"
 
-	"github.com/barweiss/go-tuple"
 	"github.com/stretchr/testify/require"
 )
 
-func TestT2_New(t *testing.T) {
-	tup := tuple.New2("1", "2")
-	require.Equal(t, tuple.T2[string, string]{
+func TestT1_New(t *testing.T) {
+	tup := New1("1")
+	require.Equal(t, T1[string]{
 		V1: "1",
-		V2: "2",
 	}, tup)
 }
 
-func TestT2_Len(t *testing.T) {
-	tup := tuple.New2("1", "2")
-	require.Equal(t, 2, tup.Len())
+func TestT1_Len(t *testing.T) {
+	tup := New1("1")
+	require.Equal(t, 1, tup.Len())
 }
 
-func TestT2_Values(t *testing.T) {
-	tup := tuple.New2("1", "2")
-	v1, v2 := tup.Values()
+func TestT1_Values(t *testing.T) {
+	tup := New1("1")
+	v1 := tup.Values()
 	require.Equal(t, "1", v1)
-	require.Equal(t, "2", v2)
 }
 
-func TestT2_String(t *testing.T) {
-	tup := tuple.New2("1", "2")
-	require.Equal(t, `["1" "2"]`, tup.String())
+func TestT1_String(t *testing.T) {
+	tup := New1("1")
+	require.Equal(t, `["1"]`, tup.String())
 }
 
-func TestT2_GoString(t *testing.T) {
-	tup := tuple.New2("1", "2")
-	require.Equal(t, `tuple.T2[string, string]{V1: "1", V2: "2"}`, tup.GoString())
+func TestT1_GoString(t *testing.T) {
+	tup := New1("1")
+	require.Equal(t, `tuple.T1[string]{V1: "1"}`, tup.GoString())
 }
 
-func TestT2_ToArray(t *testing.T) {
-	tup := tuple.New2("1", "2")
-	require.Equal(t, [2]any{
-		"1", "2",
+func TestT1_ToArray(t *testing.T) {
+	tup := New1("1")
+	require.Equal(t, [1]any{
+		"1",
 	}, tup.Array())
 }
 
-func TestT2_ToSlice(t *testing.T) {
-	tup := tuple.New2("1", "2")
+func TestT1_ToSlice(t *testing.T) {
+	tup := New1("1")
 	require.Equal(t, []any{
-		"1", "2",
+		"1",
 	}, tup.Slice())
 }
 
-func TestT2_FromArrayX(t *testing.T) {
+func TestT1_FromArrayX(t *testing.T) {
 	tests := []struct {
 		name      string
-		array     [2]any
+		array     [1]any
 		wantPanic bool
 	}{
 		{
 			name: "all types match",
-			array: [2]any{
-				"1", "2",
+			array: [1]any{
+				"1",
 			},
 			wantPanic: false,
 		},
 
 		{
 			name:      "index 1 bad type",
-			array:     [2]any{0, "1"},
-			wantPanic: true,
-		},
-
-		{
-			name:      "index 2 bad type",
-			array:     [2]any{"0", 1},
+			array:     [1]any{0},
 			wantPanic: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			do := func() tuple.T2[string, string] {
-				return tuple.FromArray2X[string, string](tt.array)
+			do := func() T1[string] {
+				return FromArray1X[string](tt.array)
 			}
 
 			if tt.wantPanic {
@@ -91,53 +82,47 @@ func TestT2_FromArrayX(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, tuple.New2("1", "2"), do())
+			require.Equal(t, New1("1"), do())
 		})
 	}
 }
 
-func TestT2_FromArray(t *testing.T) {
+func TestT1_FromArray(t *testing.T) {
 	tests := []struct {
 		name    string
-		array   [2]any
+		array   [1]any
 		wantErr bool
 	}{
 		{
 			name: "all types match",
-			array: [2]any{
-				"1", "2",
+			array: [1]any{
+				"1",
 			},
 			wantErr: false,
 		},
 
 		{
 			name:    "index 1 bad type",
-			array:   [2]any{1, "2"},
-			wantErr: true,
-		},
-
-		{
-			name:    "index 2 bad type",
-			array:   [2]any{"1", 2},
+			array:   [1]any{1},
 			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tup, err := tuple.FromArray2[string, string](tt.array)
+			tup, err := FromArray1[string](tt.array)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tuple.New2("1", "2"), tup)
+			require.Equal(t, New1("1"), tup)
 		})
 	}
 }
 
-func TestT2_FromSliceX(t *testing.T) {
+func TestT1_FromSliceX(t *testing.T) {
 	tests := []struct {
 		name      string
 		slice     []any
@@ -146,7 +131,7 @@ func TestT2_FromSliceX(t *testing.T) {
 		{
 			name: "all types match",
 			slice: []any{
-				"1", "2",
+				"1",
 			},
 			wantPanic: false,
 		},
@@ -163,7 +148,7 @@ func TestT2_FromSliceX(t *testing.T) {
 		{
 			name: "slice too long",
 			slice: []any{
-				"1", "2",
+				"1",
 				"extra",
 			},
 			wantPanic: true,
@@ -171,21 +156,15 @@ func TestT2_FromSliceX(t *testing.T) {
 
 		{
 			name:      "index 1 bad type",
-			slice:     []any{0, "1"},
-			wantPanic: true,
-		},
-
-		{
-			name:      "index 2 bad type",
-			slice:     []any{"0", 1},
+			slice:     []any{0},
 			wantPanic: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			do := func() tuple.T2[string, string] {
-				return tuple.FromSlice2X[string, string](tt.slice)
+			do := func() T1[string] {
+				return FromSlice1X[string](tt.slice)
 			}
 
 			if tt.wantPanic {
@@ -195,12 +174,12 @@ func TestT2_FromSliceX(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, tuple.New2("1", "2"), do())
+			require.Equal(t, New1("1"), do())
 		})
 	}
 }
 
-func TestT2_FromSlice(t *testing.T) {
+func TestT1_FromSlice(t *testing.T) {
 	tests := []struct {
 		name    string
 		slice   []any
@@ -209,7 +188,7 @@ func TestT2_FromSlice(t *testing.T) {
 		{
 			name: "all types match",
 			slice: []any{
-				"1", "2",
+				"1",
 			},
 			wantErr: false,
 		},
@@ -226,7 +205,7 @@ func TestT2_FromSlice(t *testing.T) {
 		{
 			name: "slice too long",
 			slice: []any{
-				"1", "2",
+				"1",
 				"extra",
 			},
 			wantErr: true,
@@ -234,27 +213,21 @@ func TestT2_FromSlice(t *testing.T) {
 
 		{
 			name:    "index 1 bad type",
-			slice:   []any{1, "2"},
-			wantErr: true,
-		},
-
-		{
-			name:    "index 2 bad type",
-			slice:   []any{"1", 2},
+			slice:   []any{1},
 			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tup, err := tuple.FromSlice2[string, string](tt.slice)
+			tup, err := FromSlice1[string](tt.slice)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tuple.New2("1", "2"), tup)
+			require.Equal(t, New1("1"), tup)
 		})
 	}
 }

--- a/tuple2_test.go
+++ b/tuple2_test.go
@@ -1,79 +1,86 @@
-package tuple_test
+package tuple
 
 import (
 	"testing"
 
-	"github.com/barweiss/go-tuple"
 	"github.com/stretchr/testify/require"
 )
 
-func TestT1_New(t *testing.T) {
-	tup := tuple.New1("1")
-	require.Equal(t, tuple.T1[string]{
+func TestT2_New(t *testing.T) {
+	tup := New2("1", "2")
+	require.Equal(t, T2[string, string]{
 		V1: "1",
+		V2: "2",
 	}, tup)
 }
 
-func TestT1_Len(t *testing.T) {
-	tup := tuple.New1("1")
-	require.Equal(t, 1, tup.Len())
+func TestT2_Len(t *testing.T) {
+	tup := New2("1", "2")
+	require.Equal(t, 2, tup.Len())
 }
 
-func TestT1_Values(t *testing.T) {
-	tup := tuple.New1("1")
-	v1 := tup.Values()
+func TestT2_Values(t *testing.T) {
+	tup := New2("1", "2")
+	v1, v2 := tup.Values()
 	require.Equal(t, "1", v1)
+	require.Equal(t, "2", v2)
 }
 
-func TestT1_String(t *testing.T) {
-	tup := tuple.New1("1")
-	require.Equal(t, `["1"]`, tup.String())
+func TestT2_String(t *testing.T) {
+	tup := New2("1", "2")
+	require.Equal(t, `["1" "2"]`, tup.String())
 }
 
-func TestT1_GoString(t *testing.T) {
-	tup := tuple.New1("1")
-	require.Equal(t, `tuple.T1[string]{V1: "1"}`, tup.GoString())
+func TestT2_GoString(t *testing.T) {
+	tup := New2("1", "2")
+	require.Equal(t, `tuple.T2[string, string]{V1: "1", V2: "2"}`, tup.GoString())
 }
 
-func TestT1_ToArray(t *testing.T) {
-	tup := tuple.New1("1")
-	require.Equal(t, [1]any{
-		"1",
+func TestT2_ToArray(t *testing.T) {
+	tup := New2("1", "2")
+	require.Equal(t, [2]any{
+		"1", "2",
 	}, tup.Array())
 }
 
-func TestT1_ToSlice(t *testing.T) {
-	tup := tuple.New1("1")
+func TestT2_ToSlice(t *testing.T) {
+	tup := New2("1", "2")
 	require.Equal(t, []any{
-		"1",
+		"1", "2",
 	}, tup.Slice())
 }
 
-func TestT1_FromArrayX(t *testing.T) {
+func TestT2_FromArrayX(t *testing.T) {
 	tests := []struct {
 		name      string
-		array     [1]any
+		array     [2]any
 		wantPanic bool
 	}{
 		{
 			name: "all types match",
-			array: [1]any{
-				"1",
+			array: [2]any{
+				"1", "2",
 			},
 			wantPanic: false,
 		},
 
 		{
 			name:      "index 1 bad type",
-			array:     [1]any{0},
+			array:     [2]any{0, "1"},
+			wantPanic: true,
+		},
+
+		{
+			name:      "index 2 bad type",
+			array:     [2]any{"0", 1},
 			wantPanic: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			do := func() tuple.T1[string] {
-				return tuple.FromArray1X[string](tt.array)
+			do := func() T2[string, string] {
+				return FromArray2X[string, string](tt.array)
 			}
 
 			if tt.wantPanic {
@@ -83,47 +90,53 @@ func TestT1_FromArrayX(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, tuple.New1("1"), do())
+			require.Equal(t, New2("1", "2"), do())
 		})
 	}
 }
 
-func TestT1_FromArray(t *testing.T) {
+func TestT2_FromArray(t *testing.T) {
 	tests := []struct {
 		name    string
-		array   [1]any
+		array   [2]any
 		wantErr bool
 	}{
 		{
 			name: "all types match",
-			array: [1]any{
-				"1",
+			array: [2]any{
+				"1", "2",
 			},
 			wantErr: false,
 		},
 
 		{
 			name:    "index 1 bad type",
-			array:   [1]any{1},
+			array:   [2]any{1, "2"},
+			wantErr: true,
+		},
+
+		{
+			name:    "index 2 bad type",
+			array:   [2]any{"1", 2},
 			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tup, err := tuple.FromArray1[string](tt.array)
+			tup, err := FromArray2[string, string](tt.array)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tuple.New1("1"), tup)
+			require.Equal(t, New2("1", "2"), tup)
 		})
 	}
 }
 
-func TestT1_FromSliceX(t *testing.T) {
+func TestT2_FromSliceX(t *testing.T) {
 	tests := []struct {
 		name      string
 		slice     []any
@@ -132,7 +145,7 @@ func TestT1_FromSliceX(t *testing.T) {
 		{
 			name: "all types match",
 			slice: []any{
-				"1",
+				"1", "2",
 			},
 			wantPanic: false,
 		},
@@ -149,7 +162,7 @@ func TestT1_FromSliceX(t *testing.T) {
 		{
 			name: "slice too long",
 			slice: []any{
-				"1",
+				"1", "2",
 				"extra",
 			},
 			wantPanic: true,
@@ -157,15 +170,21 @@ func TestT1_FromSliceX(t *testing.T) {
 
 		{
 			name:      "index 1 bad type",
-			slice:     []any{0},
+			slice:     []any{0, "1"},
+			wantPanic: true,
+		},
+
+		{
+			name:      "index 2 bad type",
+			slice:     []any{"0", 1},
 			wantPanic: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			do := func() tuple.T1[string] {
-				return tuple.FromSlice1X[string](tt.slice)
+			do := func() T2[string, string] {
+				return FromSlice2X[string, string](tt.slice)
 			}
 
 			if tt.wantPanic {
@@ -175,12 +194,12 @@ func TestT1_FromSliceX(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, tuple.New1("1"), do())
+			require.Equal(t, New2("1", "2"), do())
 		})
 	}
 }
 
-func TestT1_FromSlice(t *testing.T) {
+func TestT2_FromSlice(t *testing.T) {
 	tests := []struct {
 		name    string
 		slice   []any
@@ -189,7 +208,7 @@ func TestT1_FromSlice(t *testing.T) {
 		{
 			name: "all types match",
 			slice: []any{
-				"1",
+				"1", "2",
 			},
 			wantErr: false,
 		},
@@ -206,7 +225,7 @@ func TestT1_FromSlice(t *testing.T) {
 		{
 			name: "slice too long",
 			slice: []any{
-				"1",
+				"1", "2",
 				"extra",
 			},
 			wantErr: true,
@@ -214,21 +233,27 @@ func TestT1_FromSlice(t *testing.T) {
 
 		{
 			name:    "index 1 bad type",
-			slice:   []any{1},
+			slice:   []any{1, "2"},
+			wantErr: true,
+		},
+
+		{
+			name:    "index 2 bad type",
+			slice:   []any{"1", 2},
 			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tup, err := tuple.FromSlice1[string](tt.slice)
+			tup, err := FromSlice2[string, string](tt.slice)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tuple.New1("1"), tup)
+			require.Equal(t, New2("1", "2"), tup)
 		})
 	}
 }

--- a/tuple3_test.go
+++ b/tuple3_test.go
@@ -1,15 +1,14 @@
-package tuple_test
+package tuple
 
 import (
 	"testing"
 
-	"github.com/barweiss/go-tuple"
 	"github.com/stretchr/testify/require"
 )
 
 func TestT3_New(t *testing.T) {
-	tup := tuple.New3("1", "2", "3")
-	require.Equal(t, tuple.T3[string, string, string]{
+	tup := New3("1", "2", "3")
+	require.Equal(t, T3[string, string, string]{
 		V1: "1",
 		V2: "2",
 		V3: "3",
@@ -17,12 +16,12 @@ func TestT3_New(t *testing.T) {
 }
 
 func TestT3_Len(t *testing.T) {
-	tup := tuple.New3("1", "2", "3")
+	tup := New3("1", "2", "3")
 	require.Equal(t, 3, tup.Len())
 }
 
 func TestT3_Values(t *testing.T) {
-	tup := tuple.New3("1", "2", "3")
+	tup := New3("1", "2", "3")
 	v1, v2, v3 := tup.Values()
 	require.Equal(t, "1", v1)
 	require.Equal(t, "2", v2)
@@ -30,24 +29,24 @@ func TestT3_Values(t *testing.T) {
 }
 
 func TestT3_String(t *testing.T) {
-	tup := tuple.New3("1", "2", "3")
+	tup := New3("1", "2", "3")
 	require.Equal(t, `["1" "2" "3"]`, tup.String())
 }
 
 func TestT3_GoString(t *testing.T) {
-	tup := tuple.New3("1", "2", "3")
+	tup := New3("1", "2", "3")
 	require.Equal(t, `tuple.T3[string, string, string]{V1: "1", V2: "2", V3: "3"}`, tup.GoString())
 }
 
 func TestT3_ToArray(t *testing.T) {
-	tup := tuple.New3("1", "2", "3")
+	tup := New3("1", "2", "3")
 	require.Equal(t, [3]any{
 		"1", "2", "3",
 	}, tup.Array())
 }
 
 func TestT3_ToSlice(t *testing.T) {
-	tup := tuple.New3("1", "2", "3")
+	tup := New3("1", "2", "3")
 	require.Equal(t, []any{
 		"1", "2", "3",
 	}, tup.Slice())
@@ -88,8 +87,8 @@ func TestT3_FromArrayX(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			do := func() tuple.T3[string, string, string] {
-				return tuple.FromArray3X[string, string, string](tt.array)
+			do := func() T3[string, string, string] {
+				return FromArray3X[string, string, string](tt.array)
 			}
 
 			if tt.wantPanic {
@@ -99,7 +98,7 @@ func TestT3_FromArrayX(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, tuple.New3("1", "2", "3"), do())
+			require.Equal(t, New3("1", "2", "3"), do())
 		})
 	}
 }
@@ -139,14 +138,14 @@ func TestT3_FromArray(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tup, err := tuple.FromArray3[string, string, string](tt.array)
+			tup, err := FromArray3[string, string, string](tt.array)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tuple.New3("1", "2", "3"), tup)
+			require.Equal(t, New3("1", "2", "3"), tup)
 		})
 	}
 }
@@ -206,8 +205,8 @@ func TestT3_FromSliceX(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			do := func() tuple.T3[string, string, string] {
-				return tuple.FromSlice3X[string, string, string](tt.slice)
+			do := func() T3[string, string, string] {
+				return FromSlice3X[string, string, string](tt.slice)
 			}
 
 			if tt.wantPanic {
@@ -217,7 +216,7 @@ func TestT3_FromSliceX(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, tuple.New3("1", "2", "3"), do())
+			require.Equal(t, New3("1", "2", "3"), do())
 		})
 	}
 }
@@ -277,14 +276,14 @@ func TestT3_FromSlice(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tup, err := tuple.FromSlice3[string, string, string](tt.slice)
+			tup, err := FromSlice3[string, string, string](tt.slice)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tuple.New3("1", "2", "3"), tup)
+			require.Equal(t, New3("1", "2", "3"), tup)
 		})
 	}
 }

--- a/tuple4_test.go
+++ b/tuple4_test.go
@@ -1,15 +1,14 @@
-package tuple_test
+package tuple
 
 import (
 	"testing"
 
-	"github.com/barweiss/go-tuple"
 	"github.com/stretchr/testify/require"
 )
 
 func TestT4_New(t *testing.T) {
-	tup := tuple.New4("1", "2", "3", "4")
-	require.Equal(t, tuple.T4[string, string, string, string]{
+	tup := New4("1", "2", "3", "4")
+	require.Equal(t, T4[string, string, string, string]{
 		V1: "1",
 		V2: "2",
 		V3: "3",
@@ -18,12 +17,12 @@ func TestT4_New(t *testing.T) {
 }
 
 func TestT4_Len(t *testing.T) {
-	tup := tuple.New4("1", "2", "3", "4")
+	tup := New4("1", "2", "3", "4")
 	require.Equal(t, 4, tup.Len())
 }
 
 func TestT4_Values(t *testing.T) {
-	tup := tuple.New4("1", "2", "3", "4")
+	tup := New4("1", "2", "3", "4")
 	v1, v2, v3, v4 := tup.Values()
 	require.Equal(t, "1", v1)
 	require.Equal(t, "2", v2)
@@ -32,24 +31,24 @@ func TestT4_Values(t *testing.T) {
 }
 
 func TestT4_String(t *testing.T) {
-	tup := tuple.New4("1", "2", "3", "4")
+	tup := New4("1", "2", "3", "4")
 	require.Equal(t, `["1" "2" "3" "4"]`, tup.String())
 }
 
 func TestT4_GoString(t *testing.T) {
-	tup := tuple.New4("1", "2", "3", "4")
+	tup := New4("1", "2", "3", "4")
 	require.Equal(t, `tuple.T4[string, string, string, string]{V1: "1", V2: "2", V3: "3", V4: "4"}`, tup.GoString())
 }
 
 func TestT4_ToArray(t *testing.T) {
-	tup := tuple.New4("1", "2", "3", "4")
+	tup := New4("1", "2", "3", "4")
 	require.Equal(t, [4]any{
 		"1", "2", "3", "4",
 	}, tup.Array())
 }
 
 func TestT4_ToSlice(t *testing.T) {
-	tup := tuple.New4("1", "2", "3", "4")
+	tup := New4("1", "2", "3", "4")
 	require.Equal(t, []any{
 		"1", "2", "3", "4",
 	}, tup.Slice())
@@ -96,8 +95,8 @@ func TestT4_FromArrayX(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			do := func() tuple.T4[string, string, string, string] {
-				return tuple.FromArray4X[string, string, string, string](tt.array)
+			do := func() T4[string, string, string, string] {
+				return FromArray4X[string, string, string, string](tt.array)
 			}
 
 			if tt.wantPanic {
@@ -107,7 +106,7 @@ func TestT4_FromArrayX(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, tuple.New4("1", "2", "3", "4"), do())
+			require.Equal(t, New4("1", "2", "3", "4"), do())
 		})
 	}
 }
@@ -153,14 +152,14 @@ func TestT4_FromArray(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tup, err := tuple.FromArray4[string, string, string, string](tt.array)
+			tup, err := FromArray4[string, string, string, string](tt.array)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tuple.New4("1", "2", "3", "4"), tup)
+			require.Equal(t, New4("1", "2", "3", "4"), tup)
 		})
 	}
 }
@@ -226,8 +225,8 @@ func TestT4_FromSliceX(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			do := func() tuple.T4[string, string, string, string] {
-				return tuple.FromSlice4X[string, string, string, string](tt.slice)
+			do := func() T4[string, string, string, string] {
+				return FromSlice4X[string, string, string, string](tt.slice)
 			}
 
 			if tt.wantPanic {
@@ -237,7 +236,7 @@ func TestT4_FromSliceX(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, tuple.New4("1", "2", "3", "4"), do())
+			require.Equal(t, New4("1", "2", "3", "4"), do())
 		})
 	}
 }
@@ -303,14 +302,14 @@ func TestT4_FromSlice(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tup, err := tuple.FromSlice4[string, string, string, string](tt.slice)
+			tup, err := FromSlice4[string, string, string, string](tt.slice)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tuple.New4("1", "2", "3", "4"), tup)
+			require.Equal(t, New4("1", "2", "3", "4"), tup)
 		})
 	}
 }

--- a/tuple5_test.go
+++ b/tuple5_test.go
@@ -1,15 +1,14 @@
-package tuple_test
+package tuple
 
 import (
 	"testing"
 
-	"github.com/barweiss/go-tuple"
 	"github.com/stretchr/testify/require"
 )
 
 func TestT5_New(t *testing.T) {
-	tup := tuple.New5("1", "2", "3", "4", "5")
-	require.Equal(t, tuple.T5[string, string, string, string, string]{
+	tup := New5("1", "2", "3", "4", "5")
+	require.Equal(t, T5[string, string, string, string, string]{
 		V1: "1",
 		V2: "2",
 		V3: "3",
@@ -19,12 +18,12 @@ func TestT5_New(t *testing.T) {
 }
 
 func TestT5_Len(t *testing.T) {
-	tup := tuple.New5("1", "2", "3", "4", "5")
+	tup := New5("1", "2", "3", "4", "5")
 	require.Equal(t, 5, tup.Len())
 }
 
 func TestT5_Values(t *testing.T) {
-	tup := tuple.New5("1", "2", "3", "4", "5")
+	tup := New5("1", "2", "3", "4", "5")
 	v1, v2, v3, v4, v5 := tup.Values()
 	require.Equal(t, "1", v1)
 	require.Equal(t, "2", v2)
@@ -34,24 +33,24 @@ func TestT5_Values(t *testing.T) {
 }
 
 func TestT5_String(t *testing.T) {
-	tup := tuple.New5("1", "2", "3", "4", "5")
+	tup := New5("1", "2", "3", "4", "5")
 	require.Equal(t, `["1" "2" "3" "4" "5"]`, tup.String())
 }
 
 func TestT5_GoString(t *testing.T) {
-	tup := tuple.New5("1", "2", "3", "4", "5")
+	tup := New5("1", "2", "3", "4", "5")
 	require.Equal(t, `tuple.T5[string, string, string, string, string]{V1: "1", V2: "2", V3: "3", V4: "4", V5: "5"}`, tup.GoString())
 }
 
 func TestT5_ToArray(t *testing.T) {
-	tup := tuple.New5("1", "2", "3", "4", "5")
+	tup := New5("1", "2", "3", "4", "5")
 	require.Equal(t, [5]any{
 		"1", "2", "3", "4", "5",
 	}, tup.Array())
 }
 
 func TestT5_ToSlice(t *testing.T) {
-	tup := tuple.New5("1", "2", "3", "4", "5")
+	tup := New5("1", "2", "3", "4", "5")
 	require.Equal(t, []any{
 		"1", "2", "3", "4", "5",
 	}, tup.Slice())
@@ -104,8 +103,8 @@ func TestT5_FromArrayX(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			do := func() tuple.T5[string, string, string, string, string] {
-				return tuple.FromArray5X[string, string, string, string, string](tt.array)
+			do := func() T5[string, string, string, string, string] {
+				return FromArray5X[string, string, string, string, string](tt.array)
 			}
 
 			if tt.wantPanic {
@@ -115,7 +114,7 @@ func TestT5_FromArrayX(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, tuple.New5("1", "2", "3", "4", "5"), do())
+			require.Equal(t, New5("1", "2", "3", "4", "5"), do())
 		})
 	}
 }
@@ -167,14 +166,14 @@ func TestT5_FromArray(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tup, err := tuple.FromArray5[string, string, string, string, string](tt.array)
+			tup, err := FromArray5[string, string, string, string, string](tt.array)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tuple.New5("1", "2", "3", "4", "5"), tup)
+			require.Equal(t, New5("1", "2", "3", "4", "5"), tup)
 		})
 	}
 }
@@ -246,8 +245,8 @@ func TestT5_FromSliceX(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			do := func() tuple.T5[string, string, string, string, string] {
-				return tuple.FromSlice5X[string, string, string, string, string](tt.slice)
+			do := func() T5[string, string, string, string, string] {
+				return FromSlice5X[string, string, string, string, string](tt.slice)
 			}
 
 			if tt.wantPanic {
@@ -257,7 +256,7 @@ func TestT5_FromSliceX(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, tuple.New5("1", "2", "3", "4", "5"), do())
+			require.Equal(t, New5("1", "2", "3", "4", "5"), do())
 		})
 	}
 }
@@ -329,14 +328,14 @@ func TestT5_FromSlice(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tup, err := tuple.FromSlice5[string, string, string, string, string](tt.slice)
+			tup, err := FromSlice5[string, string, string, string, string](tt.slice)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tuple.New5("1", "2", "3", "4", "5"), tup)
+			require.Equal(t, New5("1", "2", "3", "4", "5"), tup)
 		})
 	}
 }

--- a/tuple6_test.go
+++ b/tuple6_test.go
@@ -1,15 +1,14 @@
-package tuple_test
+package tuple
 
 import (
 	"testing"
 
-	"github.com/barweiss/go-tuple"
 	"github.com/stretchr/testify/require"
 )
 
 func TestT6_New(t *testing.T) {
-	tup := tuple.New6("1", "2", "3", "4", "5", "6")
-	require.Equal(t, tuple.T6[string, string, string, string, string, string]{
+	tup := New6("1", "2", "3", "4", "5", "6")
+	require.Equal(t, T6[string, string, string, string, string, string]{
 		V1: "1",
 		V2: "2",
 		V3: "3",
@@ -20,12 +19,12 @@ func TestT6_New(t *testing.T) {
 }
 
 func TestT6_Len(t *testing.T) {
-	tup := tuple.New6("1", "2", "3", "4", "5", "6")
+	tup := New6("1", "2", "3", "4", "5", "6")
 	require.Equal(t, 6, tup.Len())
 }
 
 func TestT6_Values(t *testing.T) {
-	tup := tuple.New6("1", "2", "3", "4", "5", "6")
+	tup := New6("1", "2", "3", "4", "5", "6")
 	v1, v2, v3, v4, v5, v6 := tup.Values()
 	require.Equal(t, "1", v1)
 	require.Equal(t, "2", v2)
@@ -36,24 +35,24 @@ func TestT6_Values(t *testing.T) {
 }
 
 func TestT6_String(t *testing.T) {
-	tup := tuple.New6("1", "2", "3", "4", "5", "6")
+	tup := New6("1", "2", "3", "4", "5", "6")
 	require.Equal(t, `["1" "2" "3" "4" "5" "6"]`, tup.String())
 }
 
 func TestT6_GoString(t *testing.T) {
-	tup := tuple.New6("1", "2", "3", "4", "5", "6")
+	tup := New6("1", "2", "3", "4", "5", "6")
 	require.Equal(t, `tuple.T6[string, string, string, string, string, string]{V1: "1", V2: "2", V3: "3", V4: "4", V5: "5", V6: "6"}`, tup.GoString())
 }
 
 func TestT6_ToArray(t *testing.T) {
-	tup := tuple.New6("1", "2", "3", "4", "5", "6")
+	tup := New6("1", "2", "3", "4", "5", "6")
 	require.Equal(t, [6]any{
 		"1", "2", "3", "4", "5", "6",
 	}, tup.Array())
 }
 
 func TestT6_ToSlice(t *testing.T) {
-	tup := tuple.New6("1", "2", "3", "4", "5", "6")
+	tup := New6("1", "2", "3", "4", "5", "6")
 	require.Equal(t, []any{
 		"1", "2", "3", "4", "5", "6",
 	}, tup.Slice())
@@ -112,8 +111,8 @@ func TestT6_FromArrayX(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			do := func() tuple.T6[string, string, string, string, string, string] {
-				return tuple.FromArray6X[string, string, string, string, string, string](tt.array)
+			do := func() T6[string, string, string, string, string, string] {
+				return FromArray6X[string, string, string, string, string, string](tt.array)
 			}
 
 			if tt.wantPanic {
@@ -123,7 +122,7 @@ func TestT6_FromArrayX(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, tuple.New6("1", "2", "3", "4", "5", "6"), do())
+			require.Equal(t, New6("1", "2", "3", "4", "5", "6"), do())
 		})
 	}
 }
@@ -181,14 +180,14 @@ func TestT6_FromArray(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tup, err := tuple.FromArray6[string, string, string, string, string, string](tt.array)
+			tup, err := FromArray6[string, string, string, string, string, string](tt.array)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tuple.New6("1", "2", "3", "4", "5", "6"), tup)
+			require.Equal(t, New6("1", "2", "3", "4", "5", "6"), tup)
 		})
 	}
 }
@@ -266,8 +265,8 @@ func TestT6_FromSliceX(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			do := func() tuple.T6[string, string, string, string, string, string] {
-				return tuple.FromSlice6X[string, string, string, string, string, string](tt.slice)
+			do := func() T6[string, string, string, string, string, string] {
+				return FromSlice6X[string, string, string, string, string, string](tt.slice)
 			}
 
 			if tt.wantPanic {
@@ -277,7 +276,7 @@ func TestT6_FromSliceX(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, tuple.New6("1", "2", "3", "4", "5", "6"), do())
+			require.Equal(t, New6("1", "2", "3", "4", "5", "6"), do())
 		})
 	}
 }
@@ -355,14 +354,14 @@ func TestT6_FromSlice(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tup, err := tuple.FromSlice6[string, string, string, string, string, string](tt.slice)
+			tup, err := FromSlice6[string, string, string, string, string, string](tt.slice)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tuple.New6("1", "2", "3", "4", "5", "6"), tup)
+			require.Equal(t, New6("1", "2", "3", "4", "5", "6"), tup)
 		})
 	}
 }

--- a/tuple7_test.go
+++ b/tuple7_test.go
@@ -1,15 +1,14 @@
-package tuple_test
+package tuple
 
 import (
 	"testing"
 
-	"github.com/barweiss/go-tuple"
 	"github.com/stretchr/testify/require"
 )
 
 func TestT7_New(t *testing.T) {
-	tup := tuple.New7("1", "2", "3", "4", "5", "6", "7")
-	require.Equal(t, tuple.T7[string, string, string, string, string, string, string]{
+	tup := New7("1", "2", "3", "4", "5", "6", "7")
+	require.Equal(t, T7[string, string, string, string, string, string, string]{
 		V1: "1",
 		V2: "2",
 		V3: "3",
@@ -21,12 +20,12 @@ func TestT7_New(t *testing.T) {
 }
 
 func TestT7_Len(t *testing.T) {
-	tup := tuple.New7("1", "2", "3", "4", "5", "6", "7")
+	tup := New7("1", "2", "3", "4", "5", "6", "7")
 	require.Equal(t, 7, tup.Len())
 }
 
 func TestT7_Values(t *testing.T) {
-	tup := tuple.New7("1", "2", "3", "4", "5", "6", "7")
+	tup := New7("1", "2", "3", "4", "5", "6", "7")
 	v1, v2, v3, v4, v5, v6, v7 := tup.Values()
 	require.Equal(t, "1", v1)
 	require.Equal(t, "2", v2)
@@ -38,24 +37,24 @@ func TestT7_Values(t *testing.T) {
 }
 
 func TestT7_String(t *testing.T) {
-	tup := tuple.New7("1", "2", "3", "4", "5", "6", "7")
+	tup := New7("1", "2", "3", "4", "5", "6", "7")
 	require.Equal(t, `["1" "2" "3" "4" "5" "6" "7"]`, tup.String())
 }
 
 func TestT7_GoString(t *testing.T) {
-	tup := tuple.New7("1", "2", "3", "4", "5", "6", "7")
+	tup := New7("1", "2", "3", "4", "5", "6", "7")
 	require.Equal(t, `tuple.T7[string, string, string, string, string, string, string]{V1: "1", V2: "2", V3: "3", V4: "4", V5: "5", V6: "6", V7: "7"}`, tup.GoString())
 }
 
 func TestT7_ToArray(t *testing.T) {
-	tup := tuple.New7("1", "2", "3", "4", "5", "6", "7")
+	tup := New7("1", "2", "3", "4", "5", "6", "7")
 	require.Equal(t, [7]any{
 		"1", "2", "3", "4", "5", "6", "7",
 	}, tup.Array())
 }
 
 func TestT7_ToSlice(t *testing.T) {
-	tup := tuple.New7("1", "2", "3", "4", "5", "6", "7")
+	tup := New7("1", "2", "3", "4", "5", "6", "7")
 	require.Equal(t, []any{
 		"1", "2", "3", "4", "5", "6", "7",
 	}, tup.Slice())
@@ -120,8 +119,8 @@ func TestT7_FromArrayX(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			do := func() tuple.T7[string, string, string, string, string, string, string] {
-				return tuple.FromArray7X[string, string, string, string, string, string, string](tt.array)
+			do := func() T7[string, string, string, string, string, string, string] {
+				return FromArray7X[string, string, string, string, string, string, string](tt.array)
 			}
 
 			if tt.wantPanic {
@@ -131,7 +130,7 @@ func TestT7_FromArrayX(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, tuple.New7("1", "2", "3", "4", "5", "6", "7"), do())
+			require.Equal(t, New7("1", "2", "3", "4", "5", "6", "7"), do())
 		})
 	}
 }
@@ -195,14 +194,14 @@ func TestT7_FromArray(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tup, err := tuple.FromArray7[string, string, string, string, string, string, string](tt.array)
+			tup, err := FromArray7[string, string, string, string, string, string, string](tt.array)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tuple.New7("1", "2", "3", "4", "5", "6", "7"), tup)
+			require.Equal(t, New7("1", "2", "3", "4", "5", "6", "7"), tup)
 		})
 	}
 }
@@ -286,8 +285,8 @@ func TestT7_FromSliceX(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			do := func() tuple.T7[string, string, string, string, string, string, string] {
-				return tuple.FromSlice7X[string, string, string, string, string, string, string](tt.slice)
+			do := func() T7[string, string, string, string, string, string, string] {
+				return FromSlice7X[string, string, string, string, string, string, string](tt.slice)
 			}
 
 			if tt.wantPanic {
@@ -297,7 +296,7 @@ func TestT7_FromSliceX(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, tuple.New7("1", "2", "3", "4", "5", "6", "7"), do())
+			require.Equal(t, New7("1", "2", "3", "4", "5", "6", "7"), do())
 		})
 	}
 }
@@ -381,14 +380,14 @@ func TestT7_FromSlice(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tup, err := tuple.FromSlice7[string, string, string, string, string, string, string](tt.slice)
+			tup, err := FromSlice7[string, string, string, string, string, string, string](tt.slice)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tuple.New7("1", "2", "3", "4", "5", "6", "7"), tup)
+			require.Equal(t, New7("1", "2", "3", "4", "5", "6", "7"), tup)
 		})
 	}
 }

--- a/tuple8_test.go
+++ b/tuple8_test.go
@@ -1,15 +1,14 @@
-package tuple_test
+package tuple
 
 import (
 	"testing"
 
-	"github.com/barweiss/go-tuple"
 	"github.com/stretchr/testify/require"
 )
 
 func TestT8_New(t *testing.T) {
-	tup := tuple.New8("1", "2", "3", "4", "5", "6", "7", "8")
-	require.Equal(t, tuple.T8[string, string, string, string, string, string, string, string]{
+	tup := New8("1", "2", "3", "4", "5", "6", "7", "8")
+	require.Equal(t, T8[string, string, string, string, string, string, string, string]{
 		V1: "1",
 		V2: "2",
 		V3: "3",
@@ -22,12 +21,12 @@ func TestT8_New(t *testing.T) {
 }
 
 func TestT8_Len(t *testing.T) {
-	tup := tuple.New8("1", "2", "3", "4", "5", "6", "7", "8")
+	tup := New8("1", "2", "3", "4", "5", "6", "7", "8")
 	require.Equal(t, 8, tup.Len())
 }
 
 func TestT8_Values(t *testing.T) {
-	tup := tuple.New8("1", "2", "3", "4", "5", "6", "7", "8")
+	tup := New8("1", "2", "3", "4", "5", "6", "7", "8")
 	v1, v2, v3, v4, v5, v6, v7, v8 := tup.Values()
 	require.Equal(t, "1", v1)
 	require.Equal(t, "2", v2)
@@ -40,24 +39,24 @@ func TestT8_Values(t *testing.T) {
 }
 
 func TestT8_String(t *testing.T) {
-	tup := tuple.New8("1", "2", "3", "4", "5", "6", "7", "8")
+	tup := New8("1", "2", "3", "4", "5", "6", "7", "8")
 	require.Equal(t, `["1" "2" "3" "4" "5" "6" "7" "8"]`, tup.String())
 }
 
 func TestT8_GoString(t *testing.T) {
-	tup := tuple.New8("1", "2", "3", "4", "5", "6", "7", "8")
+	tup := New8("1", "2", "3", "4", "5", "6", "7", "8")
 	require.Equal(t, `tuple.T8[string, string, string, string, string, string, string, string]{V1: "1", V2: "2", V3: "3", V4: "4", V5: "5", V6: "6", V7: "7", V8: "8"}`, tup.GoString())
 }
 
 func TestT8_ToArray(t *testing.T) {
-	tup := tuple.New8("1", "2", "3", "4", "5", "6", "7", "8")
+	tup := New8("1", "2", "3", "4", "5", "6", "7", "8")
 	require.Equal(t, [8]any{
 		"1", "2", "3", "4", "5", "6", "7", "8",
 	}, tup.Array())
 }
 
 func TestT8_ToSlice(t *testing.T) {
-	tup := tuple.New8("1", "2", "3", "4", "5", "6", "7", "8")
+	tup := New8("1", "2", "3", "4", "5", "6", "7", "8")
 	require.Equal(t, []any{
 		"1", "2", "3", "4", "5", "6", "7", "8",
 	}, tup.Slice())
@@ -128,8 +127,8 @@ func TestT8_FromArrayX(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			do := func() tuple.T8[string, string, string, string, string, string, string, string] {
-				return tuple.FromArray8X[string, string, string, string, string, string, string, string](tt.array)
+			do := func() T8[string, string, string, string, string, string, string, string] {
+				return FromArray8X[string, string, string, string, string, string, string, string](tt.array)
 			}
 
 			if tt.wantPanic {
@@ -139,7 +138,7 @@ func TestT8_FromArrayX(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, tuple.New8("1", "2", "3", "4", "5", "6", "7", "8"), do())
+			require.Equal(t, New8("1", "2", "3", "4", "5", "6", "7", "8"), do())
 		})
 	}
 }
@@ -209,14 +208,14 @@ func TestT8_FromArray(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tup, err := tuple.FromArray8[string, string, string, string, string, string, string, string](tt.array)
+			tup, err := FromArray8[string, string, string, string, string, string, string, string](tt.array)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tuple.New8("1", "2", "3", "4", "5", "6", "7", "8"), tup)
+			require.Equal(t, New8("1", "2", "3", "4", "5", "6", "7", "8"), tup)
 		})
 	}
 }
@@ -306,8 +305,8 @@ func TestT8_FromSliceX(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			do := func() tuple.T8[string, string, string, string, string, string, string, string] {
-				return tuple.FromSlice8X[string, string, string, string, string, string, string, string](tt.slice)
+			do := func() T8[string, string, string, string, string, string, string, string] {
+				return FromSlice8X[string, string, string, string, string, string, string, string](tt.slice)
 			}
 
 			if tt.wantPanic {
@@ -317,7 +316,7 @@ func TestT8_FromSliceX(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, tuple.New8("1", "2", "3", "4", "5", "6", "7", "8"), do())
+			require.Equal(t, New8("1", "2", "3", "4", "5", "6", "7", "8"), do())
 		})
 	}
 }
@@ -407,14 +406,14 @@ func TestT8_FromSlice(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tup, err := tuple.FromSlice8[string, string, string, string, string, string, string, string](tt.slice)
+			tup, err := FromSlice8[string, string, string, string, string, string, string, string](tt.slice)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tuple.New8("1", "2", "3", "4", "5", "6", "7", "8"), tup)
+			require.Equal(t, New8("1", "2", "3", "4", "5", "6", "7", "8"), tup)
 		})
 	}
 }

--- a/tuple9_test.go
+++ b/tuple9_test.go
@@ -1,15 +1,14 @@
-package tuple_test
+package tuple
 
 import (
 	"testing"
 
-	"github.com/barweiss/go-tuple"
 	"github.com/stretchr/testify/require"
 )
 
 func TestT9_New(t *testing.T) {
-	tup := tuple.New9("1", "2", "3", "4", "5", "6", "7", "8", "9")
-	require.Equal(t, tuple.T9[string, string, string, string, string, string, string, string, string]{
+	tup := New9("1", "2", "3", "4", "5", "6", "7", "8", "9")
+	require.Equal(t, T9[string, string, string, string, string, string, string, string, string]{
 		V1: "1",
 		V2: "2",
 		V3: "3",
@@ -23,12 +22,12 @@ func TestT9_New(t *testing.T) {
 }
 
 func TestT9_Len(t *testing.T) {
-	tup := tuple.New9("1", "2", "3", "4", "5", "6", "7", "8", "9")
+	tup := New9("1", "2", "3", "4", "5", "6", "7", "8", "9")
 	require.Equal(t, 9, tup.Len())
 }
 
 func TestT9_Values(t *testing.T) {
-	tup := tuple.New9("1", "2", "3", "4", "5", "6", "7", "8", "9")
+	tup := New9("1", "2", "3", "4", "5", "6", "7", "8", "9")
 	v1, v2, v3, v4, v5, v6, v7, v8, v9 := tup.Values()
 	require.Equal(t, "1", v1)
 	require.Equal(t, "2", v2)
@@ -42,24 +41,24 @@ func TestT9_Values(t *testing.T) {
 }
 
 func TestT9_String(t *testing.T) {
-	tup := tuple.New9("1", "2", "3", "4", "5", "6", "7", "8", "9")
+	tup := New9("1", "2", "3", "4", "5", "6", "7", "8", "9")
 	require.Equal(t, `["1" "2" "3" "4" "5" "6" "7" "8" "9"]`, tup.String())
 }
 
 func TestT9_GoString(t *testing.T) {
-	tup := tuple.New9("1", "2", "3", "4", "5", "6", "7", "8", "9")
+	tup := New9("1", "2", "3", "4", "5", "6", "7", "8", "9")
 	require.Equal(t, `tuple.T9[string, string, string, string, string, string, string, string, string]{V1: "1", V2: "2", V3: "3", V4: "4", V5: "5", V6: "6", V7: "7", V8: "8", V9: "9"}`, tup.GoString())
 }
 
 func TestT9_ToArray(t *testing.T) {
-	tup := tuple.New9("1", "2", "3", "4", "5", "6", "7", "8", "9")
+	tup := New9("1", "2", "3", "4", "5", "6", "7", "8", "9")
 	require.Equal(t, [9]any{
 		"1", "2", "3", "4", "5", "6", "7", "8", "9",
 	}, tup.Array())
 }
 
 func TestT9_ToSlice(t *testing.T) {
-	tup := tuple.New9("1", "2", "3", "4", "5", "6", "7", "8", "9")
+	tup := New9("1", "2", "3", "4", "5", "6", "7", "8", "9")
 	require.Equal(t, []any{
 		"1", "2", "3", "4", "5", "6", "7", "8", "9",
 	}, tup.Slice())
@@ -136,8 +135,8 @@ func TestT9_FromArrayX(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			do := func() tuple.T9[string, string, string, string, string, string, string, string, string] {
-				return tuple.FromArray9X[string, string, string, string, string, string, string, string, string](tt.array)
+			do := func() T9[string, string, string, string, string, string, string, string, string] {
+				return FromArray9X[string, string, string, string, string, string, string, string, string](tt.array)
 			}
 
 			if tt.wantPanic {
@@ -147,7 +146,7 @@ func TestT9_FromArrayX(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, tuple.New9("1", "2", "3", "4", "5", "6", "7", "8", "9"), do())
+			require.Equal(t, New9("1", "2", "3", "4", "5", "6", "7", "8", "9"), do())
 		})
 	}
 }
@@ -223,14 +222,14 @@ func TestT9_FromArray(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tup, err := tuple.FromArray9[string, string, string, string, string, string, string, string, string](tt.array)
+			tup, err := FromArray9[string, string, string, string, string, string, string, string, string](tt.array)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tuple.New9("1", "2", "3", "4", "5", "6", "7", "8", "9"), tup)
+			require.Equal(t, New9("1", "2", "3", "4", "5", "6", "7", "8", "9"), tup)
 		})
 	}
 }
@@ -326,8 +325,8 @@ func TestT9_FromSliceX(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			do := func() tuple.T9[string, string, string, string, string, string, string, string, string] {
-				return tuple.FromSlice9X[string, string, string, string, string, string, string, string, string](tt.slice)
+			do := func() T9[string, string, string, string, string, string, string, string, string] {
+				return FromSlice9X[string, string, string, string, string, string, string, string, string](tt.slice)
 			}
 
 			if tt.wantPanic {
@@ -337,7 +336,7 @@ func TestT9_FromSliceX(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, tuple.New9("1", "2", "3", "4", "5", "6", "7", "8", "9"), do())
+			require.Equal(t, New9("1", "2", "3", "4", "5", "6", "7", "8", "9"), do())
 		})
 	}
 }
@@ -433,14 +432,14 @@ func TestT9_FromSlice(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tup, err := tuple.FromSlice9[string, string, string, string, string, string, string, string, string](tt.slice)
+			tup, err := FromSlice9[string, string, string, string, string, string, string, string, string](tt.slice)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tuple.New9("1", "2", "3", "4", "5", "6", "7", "8", "9"), tup)
+			require.Equal(t, New9("1", "2", "3", "4", "5", "6", "7", "8", "9"), tup)
 		})
 	}
 }


### PR DESCRIPTION
Reverts barweiss/go-tuple#5

I'm reverting this because Go coverage tools expect the test files to be in the same package as the tested files, otherwise coverage detection will be off.