### PR TITLE
fix: use golang.org/x/exp/constraints

### DIFF
--- a/scripts/gen/tuple.tpl
+++ b/scripts/gen/tuple.tpl
@@ -2,7 +2,7 @@ package tuple
 
 import (
 	"fmt"
-	"constraints"
+	"golang.org/x/exp/constraints"
 )
 
 {{/* $typeRef can be used when the context of dot changes. */}}

--- a/tuple1.go
+++ b/tuple1.go
@@ -1,8 +1,8 @@
 package tuple
 
 import (
-	"constraints"
 	"fmt"
+	"golang.org/x/exp/constraints"
 )
 
 // T1 is a tuple type holding 1 generic values.

--- a/tuple2.go
+++ b/tuple2.go
@@ -1,8 +1,8 @@
 package tuple
 
 import (
-	"constraints"
 	"fmt"
+	"golang.org/x/exp/constraints"
 )
 
 // T2 is a tuple type holding 2 generic values.

--- a/tuple3.go
+++ b/tuple3.go
@@ -1,8 +1,8 @@
 package tuple
 
 import (
-	"constraints"
 	"fmt"
+	"golang.org/x/exp/constraints"
 )
 
 // T3 is a tuple type holding 3 generic values.

--- a/tuple4.go
+++ b/tuple4.go
@@ -1,8 +1,8 @@
 package tuple
 
 import (
-	"constraints"
 	"fmt"
+	"golang.org/x/exp/constraints"
 )
 
 // T4 is a tuple type holding 4 generic values.

--- a/tuple5.go
+++ b/tuple5.go
@@ -1,8 +1,8 @@
 package tuple
 
 import (
-	"constraints"
 	"fmt"
+	"golang.org/x/exp/constraints"
 )
 
 // T5 is a tuple type holding 5 generic values.

--- a/tuple6.go
+++ b/tuple6.go
@@ -1,8 +1,8 @@
 package tuple
 
 import (
-	"constraints"
 	"fmt"
+	"golang.org/x/exp/constraints"
 )
 
 // T6 is a tuple type holding 6 generic values.

--- a/tuple7.go
+++ b/tuple7.go
@@ -1,8 +1,8 @@
 package tuple
 
 import (
-	"constraints"
 	"fmt"
+	"golang.org/x/exp/constraints"
 )
 
 // T7 is a tuple type holding 7 generic values.

--- a/tuple8.go
+++ b/tuple8.go
@@ -1,8 +1,8 @@
 package tuple
 
 import (
-	"constraints"
 	"fmt"
+	"golang.org/x/exp/constraints"
 )
 
 // T8 is a tuple type holding 8 generic values.

--- a/tuple9.go
+++ b/tuple9.go
@@ -1,8 +1,8 @@
 package tuple
 
 import (
-	"constraints"
 	"fmt"
+	"golang.org/x/exp/constraints"
 )
 
 // T9 is a tuple type holding 9 generic values.


### PR DESCRIPTION
The constraints builtin has been removed as per [this issue](https://github.com/golang/go/issues/50792), so this PR switches things to use that now that 1.18 is [officially released](https://go.dev/blog/go1.18).